### PR TITLE
fix empty slug or empty tags bug

### DIFF
--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -26,7 +26,7 @@ const Card = ({
   headerImage,
   headerBackgroundColor,
   description,
-  tags,
+  tags = [],
 }) => (
   <div className="col-sm-12 pb-4">
     <div className="custom-card">

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -50,7 +50,7 @@ const Page = ({ pageContext, location }) => {
         <Sidebar />
         <div className="col-xl-6 col-lg-7 col-md-12 col-xs-12 order-2">
           {group.map(({ node }) => (
-            <Card {...node.frontmatter} key={node.fields.slug} />
+            <Card {...node.frontmatter} url={node.frontmatter.slug ? node.frontmatter.slug : node.fields.slug} key={node.fields.slug} />
           ))}
 
           <div


### PR DESCRIPTION

## Description
当发布文章slug 或 tags 为空时会出现bug。

当slug为空时，首页文章url定向为 ‘/’，当tags为空时，tags不能遍历。
